### PR TITLE
Fix bug: Parsers goes in infinite cycle when template contains just tag name 

### DIFF
--- a/lib/mask.js
+++ b/lib/mask.js
@@ -518,7 +518,7 @@ window.mask = (function(w, d) {
 
 				var start = T.index;
 				do(c = T.template.charCodeAt(++T.index))
-				while (c !== 32 && c !== 35 && c !== 46 && c !== 59 && c !== 123 && c !== 62); /** while !: ' ', # , . , ; , { <*/
+				while (c !== 32 && c !== 35 && c !== 46 && c !== 59 && c !== 123 && c !== 62 && T.index <= T.length); /** while !: ' ', # , . , ; , { <*/
 
 
 				var tagName = T.template.substring(start, T.index);


### PR DESCRIPTION
[Solve for issue](https://github.com/tenbits/MaskJS/issues/2)
